### PR TITLE
docs: add Hanzilla Canada new-grad resource

### DIFF
--- a/Canada.md
+++ b/Canada.md
@@ -38,6 +38,7 @@ This repo is inspired by [Pitt CSC & Simplify Repo](https://github.com/SimplifyJ
  - 🔒 - Job application is closed
 
  > For Canadian new-grad roles, check out [Canada-New-Grad](https://github.com/cvrve/New-Grad/blob/dev/Canada.md).
+ > Supplemental Canada-wide student/recent-grad board: [Hanzilla Jobs](https://jobs.hanzilla.co/new-grad/) lists daily-updated Canadian new-grad, junior, internship, and co-op roles across tech plus adjacent fields.
 
 [⬇️ Jump to bottom ⬇️](https://github.com/cvrve/New-Grad#we-love-our-contributors-%EF%B8%8F%EF%B8%8F)
 <!-- Please leave a one line gap between this and the table TABLE_START (DO NOT CHANGE THIS LINE) -->


### PR DESCRIPTION
## Summary
- Adds Hanzilla Jobs as a supplemental Canada-wide student/recent-grad job board near the Canadian new-grad list note.
- Deep links to the new-grad landing page so Canadian students can find daily-updated new-grad, junior, internship, and co-op roles in one place.

## Why
This repo already has a Canada-specific page; Hanzilla is a free Canada-focused board that complements the table with broader student/recent-grad coverage across tech plus adjacent fields.

## Test plan
- README-only/docs change; no code tests needed.
